### PR TITLE
Move script to <body>, Closure page scripts and fix git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "app/libs/PEST"]
-	path = app/libs/PEST
-	url = https://github.com/lightsing/PESTest-NG.js.git

--- a/app/home.html
+++ b/app/home.html
@@ -6,11 +6,6 @@
     <link rel="stylesheet" type="text/css" href="stylesheets/material.css">
     <!--link rel="stylesheet" media="screen" href="stylesheets/style.css"-->
     <link rel="stylesheet" type="text/css" href="stylesheets/material-icons.css">
-    <script>if (typeof module === 'object') {window.module = module; module = undefined;}</script>
-    <script src="javascripts/material.js" charset="utf-8"></script>
-		<script src="../node_modules/jquery/dist/jquery.js"></script>
-		<script src="javascripts/home.js"></script>
-    <script>if (window.module) module = window.module;</script>
   </head>
   <body style="margin:0 auto; width: 100%;height: 100%;">
     <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
@@ -41,7 +36,13 @@
       <div class="mdl-snackbar__text"></div>
       <button class="mdl-snackbar__action" type="button"></button>
     </div>
+    <script>if (typeof module === 'object') {window.module = module; module = undefined;}</script>
+    <script src="javascripts/material.js" charset="utf-8"></script>
+		<script src="../node_modules/jquery/dist/jquery.js"></script>
+		<script src="javascripts/home.js"></script>
+    <script>if (window.module) module = window.module;</script>
     <script>
+    (function() {
       function hidetoast() {
         var toast = $('#toast');
         toast.removeClass('mdl-snackbar--active');
@@ -77,6 +78,7 @@
         complete();
         $("#schoolName").text(client.user.schoolName);
       });
+    })();
     </script>
   </body>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -5,11 +5,6 @@
     <title>Welcome Back</title>
     <link rel="stylesheet" type="text/css" href="stylesheets/material.css">
     <link rel="stylesheet" media="screen" href="stylesheets/style.css">
-    <script src="javascripts/material.js" charset="utf-8"></script>
-    <script src="javascripts/particles.js"></script>
-    <script src="javascripts/lib/stats.js"></script>
-		<script src="../node_modules/jquery/dist/jquery.js"></script>
-		<script src="javascripts/index.js"></script>
   </head>
   <body style="margin:0 auto;text-align: center;width: 100%;height: 100%;">
     <div id="particles-js" style="position: absolute;z-index: 0;"></div>
@@ -46,7 +41,13 @@
         <button type="button" class="mdl-button close">OK</button>
       </div>
     </dialog>
+    <script src="javascripts/material.js" charset="utf-8"></script>
+    <script src="javascripts/particles.js"></script>
+    <script src="javascripts/lib/stats.js"></script>
+		<script src="../node_modules/jquery/dist/jquery.js"></script>
+		<script src="javascripts/index.js"></script>
     <script>
+    (function() {
       particlesJS.load('particles-js', 'assets/particles.json', function() {});
       var dialog_error = document.querySelector('#dialog-error');
       $('dialog>div>.close').click(function() {
@@ -83,6 +84,7 @@
 				}
 				event.preventDefault();
 			});
+    })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Javascripts should be loaded after all dom elements are loaded. That's why I move all scripts, including `jQuery` ,  `material` and other stuffs into `<body>`. (Putting them in `<head>` also works but is not commonly done by community)

To make the script tidy I make a closure on scripts of the page.

I suppose more changes can be made on UI design of `home.html`, however, I don't have access to the database.

By the way I've added the submodule `PEST` into the repository again. Now it can behave correctly if I run `git submodule update --init` the first time I clone the whole project.